### PR TITLE
Add JAR manifest Main-Class attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,12 @@ application {
     mainClass = 'com.example.mcstats.Main'
 }
 
+jar {
+    manifest {
+        attributes('Main-Class': 'com.example.mcstats.Main')
+    }
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)


### PR DESCRIPTION
### Motivation
- Ensure the built JAR contains an executable entry point by setting the `Main-Class` manifest attribute.
- Make the module runnable both via the `application` plugin and by an explicit `jar` manifest so tools that inspect the JAR see the main class.

### Description
- Updated `build.gradle` to add a `jar` block that sets the manifest attribute `Main-Class` to `com.example.mcstats.Main`.
- Kept the existing `application { mainClass = 'com.example.mcstats.Main' }` and the Java toolchain configuration unchanged.

### Testing
- Ran `./gradlew clean jar` which failed with `Permission denied` because the wrapper was not executable in this environment.
- Ran `bash ./gradlew clean jar` which failed when the Gradle wrapper download was blocked by a proxy (`HTTP 403`).
- Ran `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 PATH=/root/.local/share/mise/installs/java/17.0.2/bin:$PATH gradle clean jar` which failed due to dependency download from Maven Central being blocked (`HTTP 403`), so the produced JAR and `META-INF/MANIFEST.MF` could not be inspected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebd7dcd34832f959f23cdd79405d8)