### PR TITLE
Handle fatal startup failures with clear logging

### DIFF
--- a/src/main/java/com/example/mcstats/Main.java
+++ b/src/main/java/com/example/mcstats/Main.java
@@ -5,12 +5,51 @@ import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 public class Main {
 
     public static void main(String[] args) {
-        SwingUtilities.invokeLater(AppFrame::new);
+        try {
+            SwingUtilities.invokeLater(() -> {
+                try {
+                    new AppFrame();
+                } catch (Throwable t) {
+                    logStartupFailure(t);
+                    System.exit(1);
+                }
+            });
+        } catch (Throwable t) {
+            logStartupFailure(t);
+            System.exit(1);
+        }
+    }
+
+    private static void logStartupFailure(Throwable t) {
+        String message = "Fatal startup error: Minecraft Stats Viewer failed to initialize.";
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        String details = message + System.lineSeparator() + sw;
+
+        System.err.println(details);
+
+        try {
+            Path logPath = Path.of(System.getProperty("user.home"), ".mcstats-startup-error.log");
+            Files.writeString(
+                    logPath,
+                    details + System.lineSeparator(),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE
+            );
+        } catch (Exception ignored) {
+            // Best effort file logging only; stderr is the primary fallback.
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Surface and persist uncaught initialization errors so users who launch the app outside an IDE can diagnose startup failures.
- Ensure any fatal error during UI construction is reported clearly and the process exits with a non‑zero status.
- Preserve Swing startup on the Event Dispatch Thread via `SwingUtilities.invokeLater` while adding robust error handling.

### Description
- Wrapped `Main.main(...)` in outer `try/catch` and added an inner `try/catch` inside the EDT runnable to catch any `Throwable` during initialization and exit with `System.exit(1)` on failure.
- Added `logStartupFailure(Throwable)` which prints a clear message and stack trace to `stderr` and attempts best‑effort persistence to `${user.home}/.mcstats-startup-error.log`.
- Updated imports and code in `src/main/java/com/example/mcstats/Main.java` to include `StringWriter`, `PrintWriter`, and `Files`/`Path` utilities used by the new logging helper.

### Testing
- Ran `./gradlew test` which failed locally due to `Permission denied` on the wrapper script; no unit tests executed.
- Ran `bash ./gradlew test` which failed because the Gradle distribution download was blocked by a proxy (`HTTP/1.1 403 Forbidden`); no tests completed successfully.
- No automated tests were added or changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebd8487c8832f9c90b0034184b8de)