### PR TITLE
Downgrade Gradle wrapper to 8.14.3 for Shadow plugin compatibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Motivation
- Ensure the build uses a Gradle version compatible with the existing Shadow plugin (`com.gradleup.shadow` 8.3.6) so packaging can run without Gradle-9-related incompatibilities while keeping the modern `application { mainClass = 'com.example.mcstats.Main' }` syntax unchanged.

### Description
- Updated `gradle/wrapper/gradle-wrapper.properties` to change `distributionUrl` from `gradle-9.0.0-bin.zip` to `gradle-8.14.3-bin.zip`; no other build files or plugin versions were modified.

### Testing
- Ran `./gradlew shadowDistTar --warning-mode all`, which failed to download the Gradle distribution due to an HTTP 403 from the network/proxy, so the wrapper run could not complete. 
- Ran `gradle --version` and attempted `gradle shadowDistTar --warning-mode all` with the local Gradle 8.14.3, which started but failed to resolve the `com.gradleup.shadow` plugin from the plugin portal due to network access restrictions, so the `:startShadowScripts` task creation could not be confirmed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec2ee7c14832fac4f9c7c3f0a1454)